### PR TITLE
Make python-bindings as optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,6 @@ harness = false
 [build-dependencies]
 syn = { version = "1.0", features = ["full"]}
 walkdir = "2"
+
+[features]
+python-bindings = []

--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ This is still early, actively being developed, the APIs are not stable and are l
 
 ## Getting Started
 
-You can run the example in the `examples` directory as `cargo run --example packet_to_json` which should display the dissected packet in the Json format.
+You can run the example in the `examples` directory as `cargo run --example packet_as_json` which should display the dissected packet in the Json format.
+By default, python bindings are disabled. If you want python bindings, use `--features="python-bindings"` command line argument while building or running the code.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,8 @@ pub mod types;
 use pyo3::prelude::*;
 
 /// Python bindings for packet dissection and sculpting in Rust (scalpel)
-#[pymodule]
 #[cfg(feature = "python-bindings")]
+#[pymodule]
 fn scalpel(py: Python, m: &PyModule) -> PyResult<()> {
     packet::register(py, m)?;
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,10 +28,12 @@ pub mod layer;
 
 pub mod types;
 
+#[cfg(feature = "python-bindings")]
 use pyo3::prelude::*;
 
 /// Python bindings for packet dissection and sculpting in Rust (scalpel)
 #[pymodule]
+#[cfg(feature = "python-bindings")]
 fn scalpel(py: Python, m: &PyModule) -> PyResult<()> {
     packet::register(py, m)?;
     Ok(())

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -174,6 +174,7 @@ impl Packet {
 
 // Python Bindings
 #[pymethods]
+#[cfg(feature = "python-bindings")]
 impl Packet {
     #[staticmethod]
     fn from_bytes_py(bytes: &[u8], encap: EncapType) -> PyResult<Self> {
@@ -187,6 +188,7 @@ impl Packet {
     }
 }
 
+#[cfg(feature = "python-bindings")]
 pub(crate) fn register(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Packet>()?;
     Ok(())

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -173,8 +173,8 @@ impl Packet {
 }
 
 // Python Bindings
-#[pymethods]
 #[cfg(feature = "python-bindings")]
+#[pymethods]
 impl Packet {
     #[staticmethod]
     fn from_bytes_py(bytes: &[u8], encap: EncapType) -> PyResult<Self> {

--- a/using-python-bindings.md
+++ b/using-python-bindings.md
@@ -67,3 +67,19 @@ FILE
 ```
 
 Now you can use scalpel provided `Packet.from_bytes_py(..)` method.
+
+
+Note: python bindings are only available when built with --feature=python-bindings argument.
+otherwise you will see following error
+```
+(pyscalpel) siddharth@siddharth-ubuntu:~/work/scalpel/target/debug$ python
+Python 3.8.10 (default, Mar 15 2022, 12:22:08)
+[GCC 9.4.0] on linux
+Type "help", "copyright", "credits" or "license" for more information.
+>>> import scalpel
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+ImportError: dynamic module does not define module export function (PyInit_scalpel)
+>>>
+```
+

--- a/using-python-bindings.md
+++ b/using-python-bindings.md
@@ -1,0 +1,69 @@
+After a clean build with `--features=python-bindings`
+
+```
+(pyscalpel) siddharth@siddharth-ubuntu:~/work/scalpel$ cd target/debug
+(pyscalpel) siddharth@siddharth-ubuntu:~/work/scalpel/target/debug$ ls
+build  deps  examples  incremental  libscalpel.d  libscalpel.rlib  libscalpel.so
+```
+
+rename libscalpel.so to scalpel.so
+```
+(pyscalpel) siddharth@siddharth-ubuntu:~/work/scalpel/target/debug$ mv libscalpel.so scalpel.so
+```
+
+start python shell and import scalpel
+```
+(pyscalpel) siddharth@siddharth-ubuntu:~/work/scalpel/target/debug$ python
+Python 3.8.10 (default, Mar 15 2022, 12:22:08)
+[GCC 9.4.0] on linux
+Type "help", "copyright", "credits" or "license" for more information.
+>>> import scalpel
+>>> help(scalpel)
+
+>>> dir(scalpel)
+['Packet', '__all__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__spec__']
+>>> help(scalpel)
+
+Help on module scalpel:
+
+NAME
+    scalpel - Python bindings for packet dissection and sculpting in Rust (scalpel)
+
+CLASSES
+    builtins.object
+        builtins.Packet
+
+    class Packet(object)
+     |  [`Packet`] is a central structure in `scalpel` containing the decoded data and some metadata.
+     |
+     |  When a byte-stream is 'dissected' by scalpel, it creates a `Packet` structure that contains the
+     |  following information.
+     |   * `data` : Optional 'data' from which this packet is constructed.
+     |   * `meta` : Metadata associated with the packet. This contains information like timestamp,
+     |              interface identifier where the data was captured etc. see `PacketMetadata` for
+     |              details.
+     |   * `layers`: A Vector of Opaque structures, each implementing the `Layer` trait. For example
+     |               Each of the following is a Layer - `Ethernet`, `IPv4`, `TCP` etc.
+     |   * `unprocessed`: The part of the original byte-stream that is not processed and captured into
+     |                    `layers` above.
+     |
+     |  Methods defined here:
+     |
+     |  as_json(...)
+     |
+     |  ----------------------------------------------------------------------
+     |  Static methods defined here:
+     |
+     |  __new__(*args, **kwargs) from builtins.type
+     |      Create and return a new object.  See help(type) for accurate signature.
+     |
+     |  from_bytes_py(...)
+
+DATA
+    __all__ = ['Packet']
+
+FILE
+    /home/siddharth/work/scalpel/target/debug/scalpel.so
+```
+
+Now you can use scalpel provided `Packet.from_bytes_py(..)` method.


### PR DESCRIPTION
Use `--features="python-bindings"` to enable support of python-bindings.
Multiple attributes on the same item are "expected" to evaluate in outside-in order.

Ref: https://users.rust-lang.org/t/is-macro-attribute-execution-order-stable/51029/4


```
siddharth@siddharth-ubuntu:~/work/scalpel$ cargo build --features=python-bindings
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
siddharth@siddharth-ubuntu:~/work/scalpel$ cargo build
   Compiling scalpel v0.0.1 (/home/siddharth/work/scalpel)
    Finished dev [unoptimized + debuginfo] target(s) in 2.06s
```