### PR TITLE
Properly make python-bindings optional

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,3 +20,7 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Build with Python Bindings
+      run: cargo build --verbose --features python-bindings
+    - name: Run tests with Python Bindings
+      run: cargo test --verbose --features python-bindings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,9 @@ crate-type = ["cdylib", "rlib"]
 hex = {version = "0.4", features = ["serde"]}
 lazy_static = "1"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "*"
+serde_json = { version = "1.0" }
 erased-serde = "0.3"
-
-[dependencies.pyo3]
-version = "0.14.5"
-features = ["extension-module"]
+pyo3 = { version = "0.14.5", features = ["extension-module"], optional=true}
 
 [dev-dependencies]
 criterion = "0.3"
@@ -50,4 +47,4 @@ syn = { version = "1.0", features = ["full"]}
 walkdir = "2"
 
 [features]
-python-bindings = []
+python-bindings = ['pyo3']

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,6 +21,7 @@ impl core::fmt::Display for Error {
 }
 
 // Python Bindings
+#[cfg(feature = "python-bindings")]
 impl std::convert::From<Error> for pyo3::PyErr {
     // TODO: Add proper error reporting
     fn from(_e: Error) -> pyo3::PyErr {

--- a/src/layers/ethernet/mod.rs
+++ b/src/layers/ethernet/mod.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 use crate::errors::Error;
 use crate::layer::Layer;
 use crate::packet::Packet;
+
 use crate::types::ENCAP_TYPE_ETH;
 use crate::types::{EtherType, LayerCreatorFn, MACAddress};
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -14,6 +14,7 @@ use crate::errors::Error;
 use crate::layer::{EmptyLayer, Layer};
 use crate::types::{EncapType, LayerCreatorFn, ENCAP_TYPE_ETH};
 
+#[cfg(feature = "python-bindings")]
 use pyo3::prelude::*;
 
 lazy_static! {
@@ -39,7 +40,7 @@ struct Timestamp {
 ///              Each of the following is a Layer - `Ethernet`, `IPv4`, `TCP` etc.
 ///  * `unprocessed`: The part of the original byte-stream that is not processed and captured into
 ///                   `layers` above.
-#[pyclass]
+#[cfg_attr(feature = "python-bindings", pyclass)]
 #[derive(Debug, Default, Serialize)]
 pub struct Packet {
     pub meta: PacketMetadata,


### PR DESCRIPTION
We were compiling the crate `pyo3` even when the Python bindings were
optional. Fixed this to make the crate compilation optional only when
`python-bindings` feature is enabled.

Also removed a `serde_json` dependency from `*` to start using `1.0`