### PR TITLE
Build on both nightly and stable on PR

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,14 +13,40 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    name: (${{ matrix.target}}, ${{ matrix.cfg_release_channel }})
+    strategy:
+      matrix:
+        target: [
+          x86_64-unknown-linux-gnu,
+        ]
+        cfg_release_channel: [ nightly, stable]
+
 
     steps:
     - uses: actions/checkout@v3
+    - name: install rustup
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup-init.sh
+        sh rustup-init.sh -y --default-toolchain none
+        rustup target add ${{ matrix.target }}
+        rustup default ${{ matrix.cfg_release_channel }}
     - name: Build
-      run: cargo build --verbose
+      run: |
+        rustc -Vv
+        cargo -V
+        cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: |
+        rustc -Vv
+        cargo -V
+        cargo test --verbose
     - name: Build with Python Bindings
-      run: cargo build --verbose --features python-bindings
+      run: |
+        rustc -Vv
+        cargo -V
+        cargo build --verbose --features python-bindings
     - name: Run tests with Python Bindings
-      run: cargo test --verbose --features python-bindings
+      run: |
+        rustc -Vv
+        cargo -V
+        cargo test --verbose --features python-bindings


### PR DESCRIPTION
Added matrix strategy to build on both stable and nightly releases of rust.