### PR TITLE
release 0.3.0 : improved `TooShort` error + logging support 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scalpel"
-version = "0.2.1"
+version = "0.3.0"
 license-file = "LICENSE"
 readme = "README.md"
 keywords = ["Wireshark", "pcap", "packet", "packet-parsing"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 erased-serde = "0.3"
 pyo3 = { version = "0.20", features = ["extension-module"], optional=true}
+log =  { version = "0.4", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"
@@ -57,3 +58,4 @@ walkdir = "2"
 
 [features]
 python-bindings = ['pyo3']
+logging = ["log"]

--- a/build.rs
+++ b/build.rs
@@ -107,6 +107,9 @@ fn main() -> std::io::Result<()> {
     output_str += "result = inner();";
 
     output_str += r#" if let Err(ref e) = result {
+    #[cfg(feature = "logging")]
+    log::error!("Error during register_defaults: {:#?}", e);
+
     eprintln!("Error : {:#?}", e);
     }"#;
 

--- a/build.rs
+++ b/build.rs
@@ -106,6 +106,10 @@ fn main() -> std::io::Result<()> {
     output_str += "INIT.call_once(|| { ";
     output_str += "result = inner();";
 
+    output_str += r#" if let Err(ref e) = result {
+    eprintln!("Error : {:#?}", e);
+    }"#;
+
     output_str += "});";
     output_str += "\n\n\tresult\n";
     output_str += "}";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "scalpel-python-bindings"
-version = "0.1.1"
+version = "0.2.1"
 requires-python = ">=3.7"
 classifiers = [
 	"Development Status :: 1 - Planning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "scalpel-python-bindings"
-version = "0.2.1"
+version = "0.3.0"
 requires-python = ">=3.7"
 classifiers = [
 	"Development Status :: 1 - Planning",

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,7 +4,11 @@
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     /// Byte Array too short
-    TooShort,
+    TooShort {
+        required: usize,
+        available: usize,
+        data: String,
+    },
     /// A generic parsing error.
     ParseError(String),
     /// A layer registration error.

--- a/src/layers/arp.rs
+++ b/src/layers/arp.rs
@@ -46,10 +46,11 @@ impl Layer for ARP {
         bytes: &[u8],
     ) -> Result<(Option<Box<dyn Layer + Send>>, usize), Error> {
         if bytes.len() < ARP_HDR_LENGTH {
-            return Err(Error::ParseError(format!(
-                "ARP Insufficient Length: {}",
-                bytes.len()
-            )));
+            return Err(Error::TooShort {
+                required: ARP_HDR_LENGTH,
+                available: bytes.len(),
+                data: hex::encode(bytes),
+            });
         }
 
         self.htype = (bytes[0] as u16) << 8 | (bytes[1] as u16);

--- a/src/layers/ethernet/mod.rs
+++ b/src/layers/ethernet/mod.rs
@@ -70,7 +70,11 @@ impl Layer for Ethernet {
         bytes: &[u8],
     ) -> Result<(Option<Box<dyn Layer + Send>>, usize), Error> {
         if bytes.len() < ETH_HEADER_LEN {
-            return Err(Error::TooShort);
+            return Err(Error::TooShort {
+                required: ETH_HEADER_LEN,
+                available: bytes.len(),
+                data: hex::encode(bytes),
+            });
         }
         self.src_mac = bytes[0..6].try_into()?;
         self.dst_mac = bytes[6..12].try_into()?;

--- a/src/layers/ipv4.rs
+++ b/src/layers/ipv4.rs
@@ -81,10 +81,11 @@ impl Layer for IPv4 {
         self.hdr_len = bytes[0] & 0x0f;
         // Length is in 4 octets
         if bytes.len() < (self.hdr_len * 4).into() {
-            return Err(Error::ParseError(format!(
-                "IPv4 too short: {}",
-                bytes.len()
-            )));
+            return Err(Error::TooShort {
+                required: self.hdr_len as usize * 4,
+                available: bytes.len(),
+                data: hex::encode(bytes),
+            });
         }
         self.tos = bytes[1];
         self.len = (bytes[2] as u16) << 8 | (bytes[3] as u16);

--- a/src/layers/ipv6.rs
+++ b/src/layers/ipv6.rs
@@ -77,10 +77,11 @@ impl Layer for IPv6 {
         bytes: &[u8],
     ) -> Result<(Option<Box<dyn Layer + Send>>, usize), Error> {
         if bytes.len() < IPV6_BASE_HDR_LEN {
-            return Err(Error::ParseError(format!(
-                "IPv6: Insufficient Length: {}",
-                bytes.len()
-            )));
+            return Err(Error::TooShort {
+                required: IPV6_BASE_HDR_LEN,
+                available: bytes.len(),
+                data: hex::encode(bytes),
+            });
         }
 
         self.version = bytes[0] >> 4;

--- a/src/layers/linux_sll.rs
+++ b/src/layers/linux_sll.rs
@@ -37,7 +37,11 @@ impl Layer for LinuxSll {
         bytes: &[u8],
     ) -> Result<(Option<Box<dyn Layer + Send>>, usize), Error> {
         if bytes.len() < LINUX_SLL_HEADER_LEN {
-            return Err(Error::TooShort);
+            return Err(Error::TooShort {
+                required: LINUX_SLL_HEADER_LEN,
+                available: bytes.len(),
+                data: hex::encode(bytes),
+            });
         }
         self.packet_type = u16::from_be_bytes(bytes[0..2].try_into().unwrap());
         self.ll_type = u16::from_be_bytes(bytes[2..4].try_into().unwrap());

--- a/src/layers/linux_sll2.rs
+++ b/src/layers/linux_sll2.rs
@@ -39,7 +39,11 @@ impl Layer for LinuxSll2 {
         bytes: &[u8],
     ) -> Result<(Option<Box<dyn Layer + Send>>, usize), Error> {
         if bytes.len() < LINUX_SLL2_HEADER_LEN {
-            return Err(Error::TooShort);
+            return Err(Error::TooShort {
+                required: LINUX_SLL2_HEADER_LEN,
+                available: bytes.len(),
+                data: hex::encode(bytes),
+            });
         }
         self.proto_type = u16::from_be_bytes(bytes[0..2].try_into().unwrap());
         self.reserved = u16::from_be_bytes(bytes[2..4].try_into().unwrap());

--- a/src/layers/m3ua.rs
+++ b/src/layers/m3ua.rs
@@ -42,7 +42,11 @@ impl Layer for M3UA {
         bytes: &[u8],
     ) -> Result<(Option<Box<dyn Layer + Send>>, usize), Error> {
         if bytes.len() < 8 {
-            return Err(Error::TooShort);
+            return Err(Error::TooShort {
+                required: 8,
+                available: bytes.len(),
+                data: hex::encode(bytes),
+            });
         }
 
         let mut start = 0;
@@ -68,7 +72,11 @@ impl Layer for M3UA {
         self.msg_length = u32::from_be_bytes(bytes[start..start + 4].try_into().unwrap());
 
         if bytes.len() < self.msg_length as usize {
-            return Err(Error::TooShort);
+            return Err(Error::TooShort {
+                required: self.msg_length as usize,
+                available: bytes.len(),
+                data: hex::encode(bytes),
+            });
         }
 
         let data_len = self.msg_length - 8;

--- a/src/layers/sctp.rs
+++ b/src/layers/sctp.rs
@@ -182,7 +182,11 @@ impl SCTP {
 
     fn process_chunk_header(bytes: &[u8]) -> Result<SCTPChunkHeader, Error> {
         if bytes.len() < 4 {
-            return Err(Error::TooShort);
+            return Err(Error::TooShort {
+                required: 4,
+                available: bytes.len(),
+                data: hex::encode(bytes),
+            });
         }
 
         let chunk_type = bytes[0];

--- a/src/layers/tcp.rs
+++ b/src/layers/tcp.rs
@@ -79,7 +79,11 @@ impl Layer for TCP {
         bytes: &[u8],
     ) -> Result<(Option<Box<dyn Layer + Send>>, usize), Error> {
         if bytes.len() < TCP_BASE_HDR_LEN {
-            return Err(Error::TooShort);
+            return Err(Error::TooShort {
+                required: TCP_BASE_HDR_LEN,
+                available: bytes.len(),
+                data: hex::encode(bytes),
+            });
         }
 
         self.src_port = (bytes[0] as u16) << 8 | (bytes[1] as u16);

--- a/src/layers/udp.rs
+++ b/src/layers/udp.rs
@@ -69,7 +69,11 @@ impl Layer for UDP {
         bytes: &[u8],
     ) -> Result<(Option<Box<dyn Layer + Send>>, usize), Error> {
         if bytes.len() < UDP_HDR_LEN {
-            return Err(Error::TooShort);
+            return Err(Error::TooShort {
+                required: UDP_HDR_LEN,
+                available: bytes.len(),
+                data: hex::encode(bytes),
+            });
         }
 
         self.src_port = (bytes[0] as u16) << 8 | (bytes[1] as u16);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,10 @@
 //! ## Opt-in Features
 //! - `python-bindings`: Python bindings for the scalpel Rust API. Currently support is to
 //!                      generate [`Packet`] structure in Python.
+//! - `logging`: Enable logging during decoding the packets. Since, packet dissection is usually
+//!              done in the fast, path, use this feature mainly for debugging packet dissections.
+//!              an error log is provided for the failing `register_defaults` function when this
+//!              feature is enabled.
 
 pub mod layers;
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -143,6 +143,9 @@ impl Packet {
             l2 = creator_fn.unwrap()();
         }
 
+        #[cfg(feature = "logging")]
+        log::debug!("L2 in packet: {}", l2.short_name());
+
         let mut current_layer = l2;
         let mut res: (Option<Box<dyn Layer + Send>>, usize);
         let mut start = 0;
@@ -166,6 +169,10 @@ impl Packet {
         if start != bytes.len() {
             let _ = core::mem::replace(&mut p.unprocessed, bytes[start..].to_vec());
         }
+
+        #[cfg(features = "logging")]
+        log::debug!("Decoded packet: {:#?}", p);
+
         Ok(p)
     }
 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -10,7 +10,7 @@ use lazy_static::lazy_static;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 
 use crate::errors::Error;
-use crate::types::{EncapType, LayerCreatorFn, ENCAP_TYPE_ETH};
+use crate::types::{EncapType, LayerCreatorFn};
 use crate::Layer;
 
 #[cfg(feature = "python-bindings")]
@@ -113,7 +113,7 @@ impl Packet {
     /// API.
     pub fn register_encap_type(encap: EncapType, creator: LayerCreatorFn) -> Result<(), Error> {
         let mut map = ENCAP_TYPES_MAP.write().unwrap();
-        if map.contains_key(&ENCAP_TYPE_ETH) {
+        if map.contains_key(&encap) {
             return Err(Error::RegisterError(format!("Encap: {}", encap)));
         }
         map.insert(encap, creator);
@@ -204,7 +204,7 @@ mod tests {
     use crate::layers::ipv4::IPV4_BASE_HDR_LEN;
     use crate::layers::ipv6::IPV6_BASE_HDR_LEN;
     use crate::layers::tcp::TCP_BASE_HDR_LEN;
-    use crate::ENCAP_TYPE_LINUX_SLL;
+    use crate::{ENCAP_TYPE_ETH, ENCAP_TYPE_LINUX_SLL};
 
     #[test]
     fn from_bytes_fail_too_short() {
@@ -293,6 +293,13 @@ mod tests {
         assert!(p.is_ok(), "{:?}", p.err());
         let p = p.unwrap();
         assert!(p.layers.len() == 4, "{:?}", p);
+    }
+
+    #[ignore]
+    #[test]
+    fn always_fail_ignore() {
+        let register_defaults = include_str!(concat!(env!("OUT_DIR"), "/register_defaults.rs"));
+        assert!(false, "{}", register_defaults);
     }
 
     #[test]


### PR DESCRIPTION
Improved the `TooShort` Error to dump expected, remaining and a dump of the current buffer.